### PR TITLE
Fix smiley helper

### DIFF
--- a/app/views/layouts/_form.html.erb
+++ b/app/views/layouts/_form.html.erb
@@ -38,7 +38,7 @@
         </div>
         <div id="smiley_helper" style="display:none">
           <h3>smiley assistant</h3>
-          <%= link_to "(´ε`) click me to close", "#", id: "smiley-helper-show"  %>
+          <%= link_to "(´ε`) click me to not close", "#", id: "smiley-helper-show"  %>
           <br />
           <% faces.each do |f| %>
             <%= link_to f, "#", class: 'insert-emoticon', data: { text:  " #{f} " }  %>


### PR DESCRIPTION
Because the close button on the smiley helper doesn't actually close it, we should update the text to reflect the current behavior.