### PR TITLE
:arrow_up: jquery-rails 4.2.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -18,7 +18,7 @@ gem 'sanitize'
 gem 'github-markdown'
 gem 'gemoji'
 
-gem 'jquery-rails'
+gem 'jquery-rails', '4.2.0'
 gem 'therubyracer'
 
 gem 'rspec-rails', :group => [:test,:development]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -95,7 +95,7 @@ GEM
       domain_name (~> 0.5)
     i18n (0.7.0)
     jmespath (1.3.1)
-    jquery-rails (4.1.1)
+    jquery-rails (4.2.0)
       rails-dom-testing (>= 1, < 3)
       railties (>= 4.2.0)
       thor (>= 0.14, < 2.0)
@@ -262,7 +262,7 @@ DEPENDENCIES
   github-markdown
   html-pipeline
   html-pipeline-youtube
-  jquery-rails
+  jquery-rails (= 4.2.0)
   kaminari
   localeapp
   negative_captcha
@@ -284,4 +284,4 @@ RUBY VERSION
    ruby 2.3.3p222
 
 BUNDLED WITH
-   1.13.6
+   1.13.7


### PR DESCRIPTION
This updates jQuery to 1.12.4. Newer jquery-rails packages use jQuery
3.x, which will require some testing.