### PR TITLE
Fix smiley assistant close

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -109,7 +109,7 @@
       return false;
     });
 
-    $('#smiley-helper-show').click(function() {
+    $('.smiley-helper-show').click(function() {
       $('#smiley_helper').fadeToggle();
       return false;
     });

--- a/app/views/layouts/_form.html.erb
+++ b/app/views/layouts/_form.html.erb
@@ -34,11 +34,11 @@
       <%= f.submit(:class => 'submitbutton', :value => 'Post') %>
       <% if SMILEY_ASSIST == true %>
         <div id="smiley_toggle">
-          <%= link_to "(´ε`)", "#", id: "smiley-helper-show" %>
+          <%= link_to "(´ε`)", "#", class: "smiley-helper-show" %>
         </div>
         <div id="smiley_helper" style="display:none">
           <h3>smiley assistant</h3>
-          <%= link_to "(´ε`) click me to close", "#", id: "smiley-helper-show"  %>
+          <%= link_to "(´ε`) click me to close", "#", class: "smiley-helper-show"  %>
           <br />
           <% faces.each do |f| %>
             <%= link_to f, "#", class: 'insert-emoticon', data: { text:  " #{f} " }  %>


### PR DESCRIPTION
This fixes a bug where clicking "(´ε`) click me to close" wouldn't
actually close the smiley assistant, because dom element id's should be
unique.