### PR TITLE
Make latests posts display horizontally instead of vertically

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -281,3 +281,8 @@ a:hover {
 #forttree-3d-content canvas {
   border-radius: 50px;
 }
+
+.forttree-box {
+  float: left;
+  margin-right: 10px;
+}

--- a/app/views/boards/index.html.erb
+++ b/app/views/boards/index.html.erb
@@ -1,8 +1,10 @@
 <h2><%= t("latest_posts") %></h2>
 <% @latest_posts.each do |post| %>
-  <h3>in <%= link_to "/#{post.board_name}/", post.board %><h3>
-  <%= link_to image_tag(post.photo.url(:thumb)), board_path(post.board) if post.photo.present? %>
-  <blockquote>
-    <%= display_content(post) %>
-  </blockquote>
+  <div class="forttree-box">
+    <h3>in <%= link_to "/#{post.board_name}/", post.board %></h3>
+    <%= link_to image_tag(post.photo.url(:thumb)), board_path(post.board) if post.photo.present? %>
+    <blockquote>
+      <%= display_content(post) %>
+    </blockquote>
+  </div>
 <% end %>


### PR DESCRIPTION
This is just an idea... I thought it looks kind of nice to fill the page
like this, let me know what you think.

![2017-01-26-221551_1282x590_scrot](https://cloud.githubusercontent.com/assets/59292/22359412/01031f28-e415-11e6-80ac-c6087934698d.png)
