### PR TITLE
Add clear fix to front-page

### DIFF
--- a/app/views/boards/index.html.erb
+++ b/app/views/boards/index.html.erb
@@ -8,3 +8,4 @@
     </blockquote>
   </div>
 <% end %>
+<div style="clear: both;"></div>


### PR DESCRIPTION
This fixes the background color on the front page - it was broken for
most of the themes with my float change.