### PR TITLE
Use Accept-Language header to set language

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -50,3 +50,4 @@ source 'https://rails-assets.org' do
 end
 
 gem 'localeapp'
+gem 'http_accept_language'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -92,6 +92,7 @@ GEM
       html-pipeline (~> 2.0)
     http-cookie (1.0.3)
       domain_name (~> 0.5)
+    http_accept_language (2.1.0)
     i18n (0.7.0)
     jmespath (1.3.1)
     jquery-rails (4.2.0)
@@ -256,6 +257,7 @@ DEPENDENCIES
   github-markdown
   html-pipeline
   html-pipeline-youtube
+  http_accept_language
   jquery-rails (= 4.2.0)
   kaminari
   localeapp

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,4 +1,5 @@
 class ApplicationController < ActionController::Base
+  include HttpAcceptLanguage::AutoLocale
   protect_from_forgery
   before_action :prepare_for_mobile
 


### PR DESCRIPTION
This is based on the instructions here, where there's the example function:
`extract_locale_from_accept_language_header`:
http://guides.rubyonrails.org/i18n.html#setup-the-rails-application-for-internationalization

> In practice, more robust code is necessary to do this reliably. Iain
> Hecker's http_accept_language library or Ryan Tomayko's locale Rack
> middleware provide solutions to this problem.

So now I can update the language in my browser preferences, and forttree
will display "latest posts" in the language I choose, if it's japanese,
spanish or danish. Still more work to do for internationalizing all the
text on the site.